### PR TITLE
Fix - ONRMP 105 - Avoid  tooltip overflow hidden 

### DIFF
--- a/src/modal/pera-onramp-modal/_pera-onramp-modal.scss
+++ b/src/modal/pera-onramp-modal/_pera-onramp-modal.scss
@@ -5,12 +5,12 @@
   top: 0;
   left: 50%;
 
-  width: 706px;
+  width: 838px;
   height: 703px;
 
   border-radius: 24px;
 
-  background-color: #ffffff;
+  background-color: transparent;
 
   transform: translate(-50%, 80px);
 
@@ -36,7 +36,7 @@
 .pera-onramp-modal__close-button {
   position: absolute;
   top: -52px;
-  right: -52px;
+  right: 14px;
 
   display: flex;
   align-items: center;
@@ -128,12 +128,5 @@
     top: 40px;
 
     opacity: 1;
-  }
-}
-
-@include for-small-screens {
-  .pera-onramp-modal {
-    width: 100%;
-    height: 100%;
   }
 }


### PR DESCRIPTION
Stretch the wrapper of iframe and set background color of it to transparent.

cc: @yigiterdev 