### PR TITLE
Fix - ONRMP 124 - Reposition launch button for mobile devices

### DIFF
--- a/src/modal/pera-onramp-modal/_pera-onramp-modal-wrapper.scss
+++ b/src/modal/pera-onramp-modal/_pera-onramp-modal-wrapper.scss
@@ -1,3 +1,5 @@
+@import "../../core/ui/style/media-queries";
+
 .pera-onramp-modal-wrapper {
   position: fixed;
   top: 0;
@@ -5,10 +7,17 @@
   left: 0;
   bottom: 0;
   z-index: 999999;
-  overflow-y: auto;
 
   width: 100vw;
   min-height: 100vh;
 
   background-color: rgba(0, 0, 0, 0.7);
+}
+
+@include for-small-screens {
+  .pera-onramp-modal-wrapper {
+    overflow-y: hidden;
+
+    min-height: 100%;
+  }
 }

--- a/src/modal/pera-onramp-modal/_pera-onramp-modal.scss
+++ b/src/modal/pera-onramp-modal/_pera-onramp-modal.scss
@@ -26,8 +26,6 @@
   height: 100%;
 
   border: none;
-
-  border: none;
   border-radius: inherit;
 
   animation: 0.7s PeraOnrampIframeAnimation ease-in-out;
@@ -45,8 +43,6 @@
 
   width: 40px;
   height: 40px;
-
-  padding: 8px;
 
   padding: 8px;
 
@@ -74,6 +70,13 @@
     transform: unset;
 
     animation: 0.5s PeraOnrampModalMobileSlideIn ease-out;
+  }
+
+  .pera-onramp-modal__onramp-iframe {
+    height: calc(100% - 40px);
+
+    border-bottom-left-radius: 0;
+    border-bottom-right-radius: 0;
   }
 
   .pera-onramp-modal__close-button {


### PR DESCRIPTION
* `min-height` of `pera_onramp_modal_wrapper` is changed to `100%` instead `100vh`.

cc: @yigiterdev 

<img src="https://user-images.githubusercontent.com/62015683/225394571-63a6996f-0b51-4f26-ab87-af5d5a9e283e.jpg" data-canonical-src="https://user-images.githubusercontent.com/62015683/225394571-63a6996f-0b51-4f26-ab87-af5d5a9e283e.jpg" width="200" height="400" />