### PR TITLE
Fix - ONRMP 133 - Make modal wrapper scrollable

### DIFF
--- a/src/modal/pera-onramp-modal/_pera-onramp-modal-wrapper.scss
+++ b/src/modal/pera-onramp-modal/_pera-onramp-modal-wrapper.scss
@@ -11,6 +11,8 @@
   width: 100vw;
   min-height: calc(100 * var(--vh));
 
+  overflow-y: auto;
+
   background-color: rgba(0, 0, 0, 0.7);
 }
 


### PR DESCRIPTION
On screens with laptop resolution (~980px height), user can not scroll to see the whole modal. 

https://user-images.githubusercontent.com/62015683/232026598-2ccc8f09-8011-46ed-b9b0-a5f0f5aa9cb0.mp4

