### PR TITLE
style(onramp-modal): web-wallet width removed

### DIFF
--- a/src/modal/pera-onramp-modal/_pera-onramp-modal.scss
+++ b/src/modal/pera-onramp-modal/_pera-onramp-modal.scss
@@ -15,10 +15,6 @@
   transform: translate(-50%, 80px);
 
   animation: 0.5s PeraOnrampModalSlideIn ease-out;
-
-  &--web-wallet {
-    width: 437px;
-  }
 }
 
 .pera-onramp-modal__onramp-iframe {


### PR DESCRIPTION
onramp-web prevented web-wallet to have the marketing side-bar on the left, we removed the logic from onramp-web and changed the width for the iframe here to be able to display the marketing side-bar.

onramp-web PR should be approved for ticket to be solved --> https://github.com/perawallet/onramp-web/pull/105

Related ticket:
https://linear.app/hipo/issue/ONRMP-134/pera-web-modal-layout